### PR TITLE
add missing tests for fightcard and skills

### DIFF
--- a/tests/test_fightcard.py
+++ b/tests/test_fightcard.py
@@ -156,3 +156,156 @@ def test_heal_damage(common_setup):
     assert fc.health == 2
     fc.heal_damage(1)
     assert fc.health == 2  # Cannot heal above max health
+
+
+def test_prepare_moves_card_from_prepline_to_computer_line(common_setup):
+    _, fc, grid, mocked_vnc = common_setup
+    prep_card = grid[0][3]
+    assert prep_card is not None
+    grid[1][3] = None  # Clear computer line slot
+    result = prep_card.prepare()
+    assert result is True
+    assert grid[0][3] is None
+    assert grid[1][3] is prep_card
+    mocked_vnc.show_card_prepare.assert_called_once_with(prep_card)
+
+
+def test_prepare_fails_when_computer_line_occupied(common_setup):
+    _, fc, grid, mocked_vnc = common_setup
+    prep_card = grid[0][3]
+    assert prep_card is not None
+    assert grid[1][3] is not None  # Computer line occupied
+    result = prep_card.prepare()
+    assert result is False
+    assert grid[0][3] is prep_card
+    mocked_vnc.show_card_prepare.assert_not_called()
+
+
+def test_attack_with_zero_power_does_nothing(common_setup):
+    _, fc, _, mocked_vnc = common_setup
+    fc.power = 0
+    fc.attack(target=None)
+    mocked_vnc.show_card_activate.assert_not_called()
+    mocked_vnc.handle_agent_damage.assert_not_called()
+
+
+def test_attack_against_agent_directly(common_setup):
+    _, fc, _, mocked_vnc = common_setup
+    fc.power = 3
+    fc.attack(target=None)
+    mocked_vnc.show_card_activate.assert_called_once_with(fc)
+    mocked_vnc.handle_agent_damage.assert_called_once_with("computer", 3)
+
+
+def test_attack_against_opposing_card(common_setup):
+    _, fc, grid, mocked_vnc = common_setup
+    fc.power = 2
+    target = grid[1][3]
+    target.health = 5
+    fc.attack(target=target)
+    mocked_vnc.show_card_activate.assert_called_once_with(fc)
+    mocked_vnc.show_card_getting_attacked.assert_called_once_with(target, fc)
+    assert target.health == 3
+
+
+def test_attack_kills_target(common_setup):
+    _, fc, grid, mocked_vnc = common_setup
+    fc.power = 10
+    target = grid[1][3]
+    target.health = 2
+    fc.attack(target=target)
+    assert target.health == 0
+    mocked_vnc.card_died.assert_called_once()
+
+
+def test_attack_overflow_damage_to_agent(common_setup):
+    _, fc, grid, mocked_vnc = common_setup
+    fc.power = 10
+    target = grid[1][3]
+    target.health = 3
+    fc.attack(target=target)
+    mocked_vnc.handle_agent_damage.assert_called_once_with("computer", 7)
+
+
+def test_attack_with_underdog_gains_power(common_setup):
+    _, fc, grid, _ = common_setup
+    fc.power = 2
+    fc.skills.add(sk.Underdog)
+    target = grid[1][3]
+    target.power = 5
+    target.health = 10
+    fc.attack(target=target)
+    assert target.health == 7  # 2 + 1 (Underdog) = 3 damage
+
+
+def test_attack_with_weakness_reduces_damage(common_setup):
+    _, fc, grid, _ = common_setup
+    fc.power = 3
+    fc.skills.add(sk.Weakness)
+    target = grid[1][3]
+    target.health = 10
+    fc.attack(target=target)
+    assert target.health == 8  # 3 - 1 (Weakness) = 2 damage
+
+
+def test_attack_with_weakness_minimum_zero_damage(common_setup):
+    _, fc, _, mocked_vnc = common_setup
+    fc.power = 1
+    fc.skills.add(sk.Weakness)
+    fc.attack(target=None)
+    mocked_vnc.show_card_activate.assert_called_once()
+    mocked_vnc.handle_agent_damage.assert_called_once_with("computer", 0)
+
+
+def test_attack_with_soaring_bypasses_target(common_setup):
+    _, fc, grid, mocked_vnc = common_setup
+    fc.power = 3
+    fc.skills.add(sk.Soaring)
+    target = grid[1][3]
+    target.health = 10
+    fc.attack(target=target)
+    mocked_vnc.handle_agent_damage.assert_called_once_with("computer", 3)
+    assert target.health == 10
+
+
+def test_attack_with_soaring_blocked_by_airdefense(common_setup):
+    _, fc, grid, _ = common_setup
+    fc.power = 3
+    fc.skills.add(sk.Soaring)
+    target = grid[1][3]
+    target.health = 10
+    target.skills.add(sk.Airdefense)
+    fc.attack(target=target)
+    assert target.health == 7
+
+
+def test_attack_with_instant_death_kills_target(common_setup):
+    _, fc, grid, mocked_vnc = common_setup
+    fc.power = 1
+    fc.skills.add(sk.InstantDeath)
+    target = grid[1][3]
+    target.health = 100
+    fc.attack(target=target)
+    assert target.health == 0
+    mocked_vnc.card_died.assert_called_once()
+
+
+def test_attack_against_target_with_spines(common_setup):
+    _, fc, grid, _ = common_setup
+    fc.power = 2
+    fc.health = 5
+    target = grid[1][3]
+    target.health = 10
+    target.skills.add(sk.Spines)
+    fc.attack(target=target)
+    assert target.health == 8
+    assert fc.health == 4
+
+
+def test_attack_computer_card_attacks_human_agent(common_setup):
+    _, _, grid, mocked_vnc = common_setup
+    grid[2][3] = None
+    computer_card = grid[1][3]
+    computer_card.power = 4
+    computer_card.attack(target=None)
+    mocked_vnc.handle_agent_damage.assert_called_once_with("human", 4)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -299,3 +299,106 @@ def test_weakness_against_agent():
     hc = Card("Human Card", 10, 2, 1, skills=[skills.Weakness])
     vnc = do_the_fight([hc], None)
     assert vnc.damagestate.diff == -9
+
+
+# ----- Direct unit tests for Shield -----
+
+
+def test_shield_absorbed_damage_first_call():
+    """Shield absorbs 1 damage on first call in a round."""
+    shield = skills.Shield()
+    absorbed = shield.absorbed_damage(5, fight_round=0)
+    assert absorbed == 1
+
+
+def test_shield_absorbed_damage_same_round():
+    """Shield absorbs 0 damage on second call in same round."""
+    shield = skills.Shield()
+    shield.absorbed_damage(5, fight_round=0)
+    absorbed = shield.absorbed_damage(5, fight_round=0)
+    assert absorbed == 0
+
+
+def test_shield_absorbed_damage_different_round():
+    """Shield absorbs 1 damage again in a new round."""
+    shield = skills.Shield()
+    shield.absorbed_damage(5, fight_round=0)
+    absorbed = shield.absorbed_damage(5, fight_round=1)
+    assert absorbed == 1
+
+
+def test_shield_absorbed_damage_zero_damage():
+    """Shield absorbs 0 when no damage to absorb."""
+    shield = skills.Shield()
+    absorbed = shield.absorbed_damage(0, fight_round=0)
+    assert absorbed == 0
+
+
+def test_shield_pre_fight_resets_state():
+    """Shield pre_fight resets _turns_used to empty list."""
+    shield = skills.Shield()
+    shield._turns_used = [0, 1, 2]
+    shield.pre_fight(None)
+    assert shield._turns_used == []
+
+
+# ----- Direct unit tests for LuckyStrike -----
+
+
+def test_luckystrike_is_lucky():
+    """LuckyStrike is_lucky returns True with lucky seed."""
+    random.seed(1)
+    ls = skills.LuckyStrike()
+    ls.pre_attack(None)
+    assert ls.is_lucky() is True
+
+
+def test_luckystrike_is_unlucky():
+    """LuckyStrike is_lucky returns False with unlucky seed."""
+    random.seed(0)
+    ls = skills.LuckyStrike()
+    ls.pre_attack(None)
+    assert ls.is_lucky() is False
+
+
+def test_luckystrike_post_attack_resets():
+    """LuckyStrike post_attack resets _is_lucky to None."""
+    ls = skills.LuckyStrike()
+    ls._is_lucky = True
+    ls.post_attack(None)
+    assert ls._is_lucky is None
+
+
+def test_luckystrike_power_up():
+    """LuckyStrike power_up_against_agent doubles power."""
+    ls = skills.LuckyStrike()
+    ls._is_lucky = True
+    assert ls.power_up_against_agent(5) == 10
+
+
+def test_luckystrike_power_up_zero():
+    """LuckyStrike power_up_against_agent with zero power stays zero."""
+    ls = skills.LuckyStrike()
+    ls._is_lucky = True
+    assert ls.power_up_against_agent(0) == 0
+
+
+# ----- Direct unit tests for Weakness -----
+
+
+def test_weakness_modify_damage():
+    """Weakness reduces damage by 1."""
+    weakness = skills.Weakness()
+    assert weakness.modify_damage(5) == 4
+
+
+def test_weakness_modify_damage_to_zero():
+    """Weakness reduces damage to minimum of 0."""
+    weakness = skills.Weakness()
+    assert weakness.modify_damage(1) == 0
+
+
+def test_weakness_modify_damage_from_zero():
+    """Weakness with 0 damage stays at 0."""
+    weakness = skills.Weakness()
+    assert weakness.modify_damage(0) == 0


### PR DESCRIPTION
Use case: Non fight simulation (pre-attack & prepare)

- Direct unit test for shield state
- Direct unit test for LuckyStrike state
- Direct unit tests for Weakness state
- Pre-attack & attack method tests